### PR TITLE
Add ability to specify custom ValidateIdentity

### DIFF
--- a/source/AccessTokenValidation/IdentityServerBearerTokenValidationAppBuilderExtensions.cs
+++ b/source/AccessTokenValidation/IdentityServerBearerTokenValidationAppBuilderExtensions.cs
@@ -86,7 +86,7 @@ namespace Owin
                 AuthenticationMode = options.AuthenticationMode,
                 AuthenticationType = options.AuthenticationType,
                 AccessTokenProvider = new ValidationEndpointTokenProvider(options, loggerFactory),
-                Provider = new ContextTokenProvider(),
+                Provider = options.TokenProvider ?? new ContextTokenProvider(),
             };
 
             return bearerOptions;
@@ -116,7 +116,7 @@ namespace Owin
                 AccessTokenFormat = tokenFormat,
                 AuthenticationMode = options.AuthenticationMode,
                 AuthenticationType = options.AuthenticationType,
-                Provider = new ContextTokenProvider()
+                Provider = options.TokenProvider ?? new ContextTokenProvider(),
             };
 
             return bearerOptions;


### PR DESCRIPTION
We have a need to call User Info after an access token has been validated. This PR adds the ability to specify the IOAuthBearerAuthenticationProvider and use an override of ValidateIdentity.