### PR TITLE
added SyncMetadataImmediately option to IdentityServerBearerTokenAuthenticationOptions 

### DIFF
--- a/source/AccessTokenValidation/IdentityServerBearerTokenAuthenticationOptions.cs
+++ b/source/AccessTokenValidation/IdentityServerBearerTokenAuthenticationOptions.cs
@@ -41,6 +41,7 @@ namespace IdentityServer3.AccessTokenValidation
             RequiredScopes = Enumerable.Empty<string>();
             ValidationResultCacheDuration = TimeSpan.FromMinutes(5);
             PreserveAccessToken = false;
+            SyncMetadataImmediately = true;
         }
 
         /// <summary>
@@ -178,5 +179,11 @@ namespace IdentityServer3.AccessTokenValidation
         /// The introspection HTTP handler.
         /// </value>
         public WebRequestHandler IntrospectionHttpHandler { get; set; }
+
+        /// <summary>
+        /// Indicates whether the discovery metadata to be synced immediately during the construction of 
+        /// the pipeline. <c>true</c> by default.
+        /// </summary>
+        public bool SyncMetadataImmediately { get; set; }
     }
 }

--- a/source/AccessTokenValidation/IdentityServerBearerTokenValidationAppBuilderExtensions.cs
+++ b/source/AccessTokenValidation/IdentityServerBearerTokenValidationAppBuilderExtensions.cs
@@ -59,6 +59,16 @@ namespace Owin
                     throw new Exception("ValidationMode has invalid value");
             }
 
+            if (options.SyncMetadataImmediately)
+            {
+                // evaluate the lazy members so that they can do their job
+                var ignore = new[]
+                {
+                    middlewareOptions.LocalValidationOptions?.Value,
+                    middlewareOptions.EndpointValidationOptions?.Value
+                };
+            }
+
             if (options.TokenProvider != null)
             {
                 middlewareOptions.TokenProvider = options.TokenProvider;
@@ -79,94 +89,102 @@ namespace Owin
             return app;
         }
 
-        private static OAuthBearerAuthenticationOptions ConfigureEndpointValidation(IdentityServerBearerTokenAuthenticationOptions options, ILoggerFactory loggerFactory)
+        private static Lazy<OAuthBearerAuthenticationOptions> ConfigureEndpointValidation(IdentityServerBearerTokenAuthenticationOptions options, ILoggerFactory loggerFactory)
         {
-            if (options.EnableValidationResultCache)
+            return new Lazy<OAuthBearerAuthenticationOptions>(() => 
             {
-                if (options.ValidationResultCache == null)
+                if (options.EnableValidationResultCache)
                 {
-                    options.ValidationResultCache = new InMemoryValidationResultCache(options);
+                    if (options.ValidationResultCache == null)
+                    {
+                        options.ValidationResultCache = new InMemoryValidationResultCache(options);
+                    }
                 }
-            }
 
-            var bearerOptions = new OAuthBearerAuthenticationOptions
-            {
-                AuthenticationMode = options.AuthenticationMode,
-                AuthenticationType = options.AuthenticationType,
-                Provider = new ContextTokenProvider(options.TokenProvider),
-            };
+                var bearerOptions = new OAuthBearerAuthenticationOptions
+                {
+                    AuthenticationMode = options.AuthenticationMode,
+                    AuthenticationType = options.AuthenticationType,
+                    Provider = new ContextTokenProvider(options.TokenProvider),
+                };
 
-            if (!string.IsNullOrEmpty(options.ClientId) || options.IntrospectionHttpHandler != null)
-            {
-                bearerOptions.AccessTokenProvider = new IntrospectionEndpointTokenProvider(options, loggerFactory);
-            }
-            else
-            {
-                bearerOptions.AccessTokenProvider = new ValidationEndpointTokenProvider(options, loggerFactory);
-            }
+                if (!string.IsNullOrEmpty(options.ClientId) || options.IntrospectionHttpHandler != null)
+                {
+                    bearerOptions.AccessTokenProvider = new IntrospectionEndpointTokenProvider(options, loggerFactory);
+                }
+                else
+                {
+                    bearerOptions.AccessTokenProvider = new ValidationEndpointTokenProvider(options, loggerFactory);
+                }
 
-            return bearerOptions;
+                return bearerOptions;
+
+            }, true);
         }
 
-        internal static OAuthBearerAuthenticationOptions ConfigureLocalValidation(IdentityServerBearerTokenAuthenticationOptions options, ILoggerFactory loggerFactory)
+        internal static Lazy<OAuthBearerAuthenticationOptions> ConfigureLocalValidation(IdentityServerBearerTokenAuthenticationOptions options, ILoggerFactory loggerFactory)
         {
-            JwtFormat tokenFormat = null;
-
-            // use static configuration
-            if (!string.IsNullOrWhiteSpace(options.IssuerName) &&
-                options.SigningCertificate != null)
+            return new Lazy<OAuthBearerAuthenticationOptions>(() => 
             {
-                var audience = options.IssuerName.EnsureTrailingSlash();
-                audience += "resources";
+                JwtFormat tokenFormat = null;
 
-                var valParams = new TokenValidationParameters
-                { 
-                    ValidIssuer = options.IssuerName,
-                    ValidAudience = audience,
-                    IssuerSigningToken = new X509SecurityToken(options.SigningCertificate),
-
-                    NameClaimType = options.NameClaimType,
-                    RoleClaimType = options.RoleClaimType,
-                };
-
-                tokenFormat = new JwtFormat(valParams);
-            }
-            else
-            {
-                // use discovery endpoint
-                if (string.IsNullOrWhiteSpace(options.Authority))
+                // use static configuration
+                if (!string.IsNullOrWhiteSpace(options.IssuerName) &&
+                    options.SigningCertificate != null)
                 {
-                    throw new Exception("Either set IssuerName and SigningCertificate - or Authority");
+                    var audience = options.IssuerName.EnsureTrailingSlash();
+                    audience += "resources";
+
+                    var valParams = new TokenValidationParameters
+                    {
+                        ValidIssuer = options.IssuerName,
+                        ValidAudience = audience,
+                        IssuerSigningToken = new X509SecurityToken(options.SigningCertificate),
+
+                        NameClaimType = options.NameClaimType,
+                        RoleClaimType = options.RoleClaimType,
+                    };
+
+                    tokenFormat = new JwtFormat(valParams);
+                }
+                else
+                {
+                    // use discovery endpoint
+                    if (string.IsNullOrWhiteSpace(options.Authority))
+                    {
+                        throw new Exception("Either set IssuerName and SigningCertificate - or Authority");
+                    }
+
+                    var discoveryEndpoint = options.Authority.EnsureTrailingSlash();
+                    discoveryEndpoint += ".well-known/openid-configuration";
+
+                    var issuerProvider = new DiscoveryDocumentIssuerSecurityTokenProvider(
+                        discoveryEndpoint,
+                        options,
+                        loggerFactory);
+
+                    var valParams = new TokenValidationParameters
+                    {
+                        ValidAudience = issuerProvider.Audience,
+                        NameClaimType = options.NameClaimType,
+                        RoleClaimType = options.RoleClaimType
+                    };
+
+                    tokenFormat = new JwtFormat(valParams, issuerProvider);
                 }
 
-                var discoveryEndpoint = options.Authority.EnsureTrailingSlash();
-                discoveryEndpoint += ".well-known/openid-configuration";
 
-                var issuerProvider = new DiscoveryDocumentIssuerSecurityTokenProvider(
-                    discoveryEndpoint,
-                    options,
-                    loggerFactory);
-
-                var valParams = new TokenValidationParameters
+                var bearerOptions = new OAuthBearerAuthenticationOptions
                 {
-                    ValidAudience = issuerProvider.Audience,
-                    NameClaimType = options.NameClaimType,
-                    RoleClaimType = options.RoleClaimType
+                    AccessTokenFormat = tokenFormat,
+                    AuthenticationMode = options.AuthenticationMode,
+                    AuthenticationType = options.AuthenticationType,
+                    Provider = new ContextTokenProvider(options.TokenProvider)
                 };
 
-                tokenFormat = new JwtFormat(valParams, issuerProvider);
-            }
-            
+                return bearerOptions;
 
-            var bearerOptions = new OAuthBearerAuthenticationOptions
-            {
-                AccessTokenFormat = tokenFormat,
-                AuthenticationMode = options.AuthenticationMode,
-                AuthenticationType = options.AuthenticationType,
-                Provider = new ContextTokenProvider(options.TokenProvider)
-            };
-
-            return bearerOptions;
+            }, true);
         }
     }
 }

--- a/source/AccessTokenValidation/Plumbing/DiscoveryDocumentIssuerSecurityTokenProvider.cs
+++ b/source/AccessTokenValidation/Plumbing/DiscoveryDocumentIssuerSecurityTokenProvider.cs
@@ -56,7 +56,11 @@ namespace IdentityServer3.AccessTokenValidation
             }
 
             _configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(discoveryEndpoint, new HttpClient(handler));
-            RetrieveMetadata();
+
+            if (options.SyncMetadataImmediately)
+            {
+                RetrieveMetadata();
+            }
         }
 
         /// <summary>

--- a/source/AccessTokenValidation/Plumbing/IdentityServerOAuthBearerAuthenticationOptions.cs
+++ b/source/AccessTokenValidation/Plumbing/IdentityServerOAuthBearerAuthenticationOptions.cs
@@ -15,6 +15,7 @@
  */
 
 using Microsoft.Owin.Security.OAuth;
+using System;
 
 namespace IdentityServer3.AccessTokenValidation
 {
@@ -37,7 +38,7 @@ namespace IdentityServer3.AccessTokenValidation
         /// <value>
         /// The local validation options.
         /// </value>
-        public OAuthBearerAuthenticationOptions LocalValidationOptions { get; set; }
+        public Lazy<OAuthBearerAuthenticationOptions> LocalValidationOptions { get; set; }
 
         /// <summary>
         /// Gets or sets the endpoint validation options.
@@ -45,6 +46,6 @@ namespace IdentityServer3.AccessTokenValidation
         /// <value>
         /// The endpoint validation options.
         /// </value>
-        public OAuthBearerAuthenticationOptions EndpointValidationOptions { get; set; }
+        public Lazy<OAuthBearerAuthenticationOptions> EndpointValidationOptions { get; set; }
     }
 }


### PR DESCRIPTION
> Damn GitHub! Pressed the Enter by mistake :smile: 

fixes #57.

I added `SyncMetadataImmediately` option to `IdentityServerBearerTokenAuthenticationOptions` which makes it evaluate the metadata sync in a lazy manner. It's true by default. Implementation felt a bit nasty. so, I am not sure if there is a better way to be handling this.

I also used a C# 6.0 feature. I am not sure if the build server is configured to build properly. I can remove it if that's not preferred.