### PR TITLE
Change base type of BackchannelHttpHandler and IntrospectionHttpHandler to HttpMessageHandler 

### DIFF
--- a/source/AccessTokenValidation/IdentityServerBearerTokenAuthenticationOptions.cs
+++ b/source/AccessTokenValidation/IdentityServerBearerTokenAuthenticationOptions.cs
@@ -82,7 +82,7 @@ namespace IdentityServer3.AccessTokenValidation
         /// <value>
         /// The backchannel HTTP handler.
         /// </value>
-        public WebRequestHandler BackchannelHttpHandler { get; set; }
+		public HttpMessageHandler BackchannelHttpHandler { get; set; }
 
         /// <summary>
         /// Gets or sets the backchannel certificate validator.
@@ -180,7 +180,7 @@ namespace IdentityServer3.AccessTokenValidation
         /// <value>
         /// The introspection HTTP handler.
         /// </value>
-        public WebRequestHandler IntrospectionHttpHandler { get; set; }
+		public HttpMessageHandler IntrospectionHttpHandler { get; set; }
 
         /// <summary>
         /// Indicates whether the discovery metadata sync to be delayed during the construction of 

--- a/source/AccessTokenValidation/Plumbing/DiscoveryDocumentIssuerSecurityTokenProvider.cs
+++ b/source/AccessTokenValidation/Plumbing/DiscoveryDocumentIssuerSecurityTokenProvider.cs
@@ -50,7 +50,7 @@ namespace IdentityServer3.AccessTokenValidation
                 var webRequestHandler = handler as WebRequestHandler;
                 if (webRequestHandler == null)
                 {
-                    throw new InvalidOperationException("Invalid certificate validator");
+					throw new InvalidOperationException("In the options are set BackchannelHttpHandler and BackchannelCertificateValidator. If you wish to use custom BackchannelCertificateValidator, BackchannelHttpHandler has to inherit from WebRequestHandler.");
                 }
                 webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate;
             }

--- a/source/AccessTokenValidation/Plumbing/IntrospectionEndpointTokenProvider.cs
+++ b/source/AccessTokenValidation/Plumbing/IntrospectionEndpointTokenProvider.cs
@@ -55,7 +55,7 @@ namespace IdentityServer3.AccessTokenValidation
                 var webRequestHandler = handler as WebRequestHandler;
                 if (webRequestHandler == null)
                 {
-                    throw new InvalidOperationException("Invalid certificate validator");
+					throw new InvalidOperationException("In the options are set IntrospectionHttpHandler and BackchannelCertificateValidator. If you wish to use custom BackchannelCertificateValidator, IntrospectionHttpHandler has to inherit from WebRequestHandler.");
                 }
 
                 webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate;

--- a/source/AccessTokenValidation/Plumbing/ValidationEndpointTokenProvider.cs
+++ b/source/AccessTokenValidation/Plumbing/ValidationEndpointTokenProvider.cs
@@ -56,7 +56,7 @@ namespace IdentityServer3.AccessTokenValidation
                 var webRequestHandler = handler as WebRequestHandler;
                 if (webRequestHandler == null)
                 {
-                    throw new InvalidOperationException("Invalid certificate validator");
+					throw new InvalidOperationException("In the options are set BackchannelHttpHandler and BackchannelCertificateValidator. If you wish to use custom BackchannelCertificateValidator, BackchannelHttpHandler has to inherit from WebRequestHandler.");
                 }
 
                 webRequestHandler.ServerCertificateValidationCallback = options.BackchannelCertificateValidator.Validate;


### PR DESCRIPTION
Changing in the options base type of BackchannelHttpHandler and IntrospectionHttpHandler from WebRequestHandler to HttpMessageHandler would allow us to use any http massage handler.

For example we could use OwinHttpMessageHandler for a backchannel communication which has a significant impact on the ability to create inmemory integration tests for an applications which uses AccessTokenValidation package.