### PR TITLE
Set response CORS headers if not already present

### DIFF
--- a/source/AccessTokenValidation.Tests/AccessTokenValidation.Tests.csproj
+++ b/source/AccessTokenValidation.Tests/AccessTokenValidation.Tests.csproj
@@ -117,6 +117,7 @@
     <Compile Include="InMemoryClaimsCacheTests.cs" />
     <Compile Include="Integration Tests\Introspection.cs" />
     <Compile Include="Integration Tests\DynamicBoth.cs" />
+    <Compile Include="Integration Tests\ResponseHeaders.cs" />
     <Compile Include="Integration Tests\StaticBoth.cs" />
     <Compile Include="Integration Tests\StaticLocal.cs" />
     <Compile Include="Integration Tests\TokenProvider.cs" />

--- a/source/AccessTokenValidation.Tests/Integration Tests/ResponseHeaders.cs
+++ b/source/AccessTokenValidation.Tests/Integration Tests/ResponseHeaders.cs
@@ -1,0 +1,77 @@
+﻿using AccessTokenValidation.Tests.Util;
+using FluentAssertions;
+using IdentityServer3.AccessTokenValidation;
+using Owin;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AccessTokenValidation.Tests.Integration_Tests
+{
+    public class ResponseHeaders
+    {
+        IdentityServerBearerTokenAuthenticationOptions _options = new IdentityServerBearerTokenAuthenticationOptions
+        {
+            IssuerName = TokenFactory.DefaultIssuer,
+            SigningCertificate = new X509Certificate2(Convert.FromBase64String(TokenFactory.DefaultPublicKey)),
+            ValidationMode = ValidationMode.Local,
+            RequiredScopes = new string[] { TokenFactory.Api2Scope }
+        };
+
+        [Fact]
+        public async Task WhenCorsHeadersAreAlreadySetOnTheResponse_LeavesThemAsIs()
+        {
+            var client = PipelineFactory.CreateHttpClient(_options, x =>
+            {
+                x.Use(async (context, next) =>
+                {
+                    context.Response.Headers.Add("Access-Control-Allow-Origin", new[] { "ACAO Value" });
+                    context.Response.Headers.Add("Access-Control-Allow-Method", new[] { "ACAM Value" });
+                    context.Response.Headers.Add("Access-Control-Allow-Headers", new[] { "ACAH Value" });
+
+                    await next();
+                });
+            });
+
+            var token = TokenFactory.CreateTokenString(TokenFactory.CreateToken(scope: new string[] { TokenFactory.Api1Scope }));
+            client.SetBearerToken(token);
+
+            var result = await client.GetAsync("http://test");
+            var responseHeaders = result.Headers;
+
+            responseHeaders.GetValues("Access-Control-Allow-Origin").Should().BeEquivalentTo("ACAO Value");
+            responseHeaders.GetValues("Access-Control-Allow-Method").Should().BeEquivalentTo("ACAM Value");
+            responseHeaders.GetValues("Access-Control-Allow-Headers").Should().BeEquivalentTo("ACAH Value");
+        }
+
+        [Fact]
+        public async Task WhenNoCorsHeadersAreAlreadySetOnTheResponse_SetsThemFromRequestSpecificHeaders()
+        {
+            var client = PipelineFactory.CreateHttpClient(_options, x =>
+            {
+                x.Use(async (context, next) =>
+                {
+                    context.Request.Headers.Add("Origin", new[] { "Origin Value" });
+                    context.Request.Headers.Add("Access-Control-Request-Method", new[] { "ACRM Value" });
+                    context.Request.Headers.Add("Access-Control-Request-Headers", new[] { "ACRH Value" });
+
+                    await next();
+                });
+            });
+
+            var token = TokenFactory.CreateTokenString(TokenFactory.CreateToken(scope: new string[] { TokenFactory.Api1Scope }));
+            client.SetBearerToken(token);
+
+            var result = await client.GetAsync("http://test");
+            var responseHeaders = result.Headers;
+
+            responseHeaders.GetValues("Access-Control-Allow-Origin").Should().BeEquivalentTo("Origin Value");
+            responseHeaders.GetValues("Access-Control-Expose-Headers").Should().BeEquivalentTo("WWW-Authenticate");
+            responseHeaders.GetValues("Access-Control-Allow-Method").Should().BeEquivalentTo("ACRM Value");
+            responseHeaders.GetValues("Access-Control-Allow-Headers").Should().BeEquivalentTo("ACRH Value");
+        }
+    }
+}

--- a/source/AccessTokenValidation.Tests/Util/PipelineFactory.cs
+++ b/source/AccessTokenValidation.Tests/Util/PipelineFactory.cs
@@ -2,6 +2,7 @@
 using Microsoft.Owin.Builder;
 using Microsoft.Owin.Logging;
 using Owin;
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -9,10 +10,12 @@ namespace AccessTokenValidation.Tests.Util
 {
     class PipelineFactory
     {
-        public static IAppBuilder Create(IdentityServerBearerTokenAuthenticationOptions options)
+        public static IAppBuilder Create(IdentityServerBearerTokenAuthenticationOptions options, Action<IAppBuilder> configure)
         {
             IAppBuilder app = new AppBuilder();
             app.SetLoggerFactory(new DiagnosticsLoggerFactory());
+
+            configure?.Invoke(app);
 
             app.UseIdentityServerBearerTokenAuthentication(options);
             
@@ -38,9 +41,9 @@ namespace AccessTokenValidation.Tests.Util
             return app;
         }
 
-        public static HttpClient CreateHttpClient(IdentityServerBearerTokenAuthenticationOptions options)
+        public static HttpClient CreateHttpClient(IdentityServerBearerTokenAuthenticationOptions options, Action<IAppBuilder> configure = null)
         {
-            var app = PipelineFactory.Create(options);
+            var app = PipelineFactory.Create(options, configure);
             var handler = new OwinHttpMessageHandler(app.Build());
             var client = new HttpClient(handler);
 

--- a/source/AccessTokenValidation/Plumbing/ScopeRequirementMiddleware.cs
+++ b/source/AccessTokenValidation/Plumbing/ScopeRequirementMiddleware.cs
@@ -89,22 +89,23 @@ namespace IdentityServer3.AccessTokenValidation
         private void EmitCorsResponseHeaders(IDictionary<string, object> env)
         {
             var ctx = new OwinContext(env);
+            var responseHeaders = ctx.Response.Headers;
             string[] values;
 
             if (ctx.Request.Headers.TryGetValue("Origin", out values))
             {
-                ctx.Response.Headers.Add("Access-Control-Allow-Origin", values);
-                ctx.Response.Headers.Add("Access-Control-Expose-Headers", new string[] { "WWW-Authenticate" });
+                SetHeaderIfNotAlreadyPresent(responseHeaders, "Access-Control-Allow-Origin", values);
+                SetHeaderIfNotAlreadyPresent(responseHeaders, "Access-Control-Expose-Headers", new string[] { "WWW-Authenticate" });
             }
 
             if (ctx.Request.Headers.TryGetValue("Access-Control-Request-Method", out values))
             {
-                ctx.Response.Headers.Add("Access-Control-Allow-Method", values);
+                SetHeaderIfNotAlreadyPresent(responseHeaders, "Access-Control-Allow-Method", values);
             }
 
             if (ctx.Request.Headers.TryGetValue("Access-Control-Request-Headers", out values))
             {
-                ctx.Response.Headers.Add("Access-Control-Allow-Headers", values);
+                SetHeaderIfNotAlreadyPresent(responseHeaders, "Access-Control-Allow-Headers", values);
             }
         }
 
@@ -126,6 +127,14 @@ namespace IdentityServer3.AccessTokenValidation
             }
 
             return false;
+        }
+
+        private static void SetHeaderIfNotAlreadyPresent(IHeaderDictionary headers, string headerName, string[] headerValues)
+        {
+            if (!headers.ContainsKey(headerName))
+            {
+                headers.Add(headerName, headerValues);
+            }
         }
     }
 }


### PR DESCRIPTION
When a valid token is found in the request but the scope requirement isn't met,
CORS headers are set on the response from the values of several request headers.
This potentially conflicts if CORS headers were already set on the response,
for example by the CORS middleware.