### PR TITLE
Fix retry behavior of discovery endpoint meta data retrieval

### DIFF
--- a/source/AccessTokenValidation.Tests/AccessTokenValidation.Tests.csproj
+++ b/source/AccessTokenValidation.Tests/AccessTokenValidation.Tests.csproj
@@ -115,6 +115,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="InMemoryClaimsCacheTests.cs" />
+    <Compile Include="Integration Tests\DynamicLocal.cs" />
     <Compile Include="Integration Tests\Introspection.cs" />
     <Compile Include="Integration Tests\DynamicBoth.cs" />
     <Compile Include="Integration Tests\ResponseHeaders.cs" />
@@ -123,6 +124,7 @@
     <Compile Include="Integration Tests\TokenProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Util\DiscoveryEndpointHandler.cs" />
+    <Compile Include="Util\FailureDiscoveryEndpointHandler.cs" />
     <Compile Include="Util\IntrospectionEndpointHandler.cs" />
     <Compile Include="Util\SuccessValidationEndointHandler.cs" />
     <Compile Include="Util\FailureValidationEndointHandler.cs" />

--- a/source/AccessTokenValidation.Tests/Integration Tests/DynamicLocal.cs
+++ b/source/AccessTokenValidation.Tests/Integration Tests/DynamicLocal.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using AccessTokenValidation.Tests.Util;
+using FluentAssertions;
+using IdentityServer3.AccessTokenValidation;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AccessTokenValidation.Tests.Integration_Tests
+{
+    public class DynamicLocal
+    {
+        IdentityServerBearerTokenAuthenticationOptions _options = new IdentityServerBearerTokenAuthenticationOptions
+        {
+            Authority = "https://discodoc",
+            ValidationMode = ValidationMode.Local,
+            DelayLoadMetadata = true
+        };
+
+        [Fact]
+        public async Task WhenDelayLoadMetadataIsTrue_MetadataRetrievalIsRetriedAfterFailure()
+        {
+            _options.BackchannelHttpHandler = new FailureDiscoveryEndpointHandler();
+
+            var client = PipelineFactory.CreateHttpClient(_options);
+            var token = TokenFactory.CreateTokenString(TokenFactory.CreateToken());
+
+            client.SetBearerToken(token);
+
+            Func<Task> action = async () => await client.GetAsync("http://test");
+            action.
+                ShouldThrow<InvalidOperationException>().
+                And.
+                Message.Should().Contain("IDX10803"); // IDX10803: Unable to create to obtain configuration from: https://discodoc
+
+            _options.BackchannelHttpHandler = new DiscoveryEndpointHandler();
+
+            var result = await client.GetAsync("http://test");
+            result.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+    }
+}

--- a/source/AccessTokenValidation.Tests/Util/FailureDiscoveryEndpointHandler.cs
+++ b/source/AccessTokenValidation.Tests/Util/FailureDiscoveryEndpointHandler.cs
@@ -1,0 +1,16 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AccessTokenValidation.Tests.Util
+{
+    class FailureDiscoveryEndpointHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.BadGateway);
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/source/AccessTokenValidation/IdentityServerBearerTokenValidationAppBuilderExtensions.cs
+++ b/source/AccessTokenValidation/IdentityServerBearerTokenValidationAppBuilderExtensions.cs
@@ -21,6 +21,7 @@ using Microsoft.Owin.Security.OAuth;
 using System;
 using System.IdentityModel.Tokens;
 using System.Linq;
+using System.Threading;
 
 namespace Owin
 {
@@ -196,7 +197,7 @@ namespace Owin
 
                 return bearerOptions;
 
-            }, true);
+            }, LazyThreadSafetyMode.PublicationOnly);
         }
     }
 }

--- a/source/AccessTokenValidation/IdentityServerBearerTokenValidationMiddleware.cs
+++ b/source/AccessTokenValidation/IdentityServerBearerTokenValidationMiddleware.cs
@@ -22,6 +22,7 @@ using Owin;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using AppFunc = System.Func<System.Collections.Generic.IDictionary<string, object>, System.Threading.Tasks.Task>;
 
@@ -60,7 +61,7 @@ namespace IdentityServer3.AccessTokenValidation
                     localBuilder.Run(ctx => next(ctx.Environment));
                     return localBuilder.Build();
 
-                }, true);
+                }, LazyThreadSafetyMode.PublicationOnly);
             }
 
             if (options.EndpointValidationOptions != null)


### PR DESCRIPTION
 - Use LazyThreadSafetyMode.PublicationOnly for local validation initialization
 - Added a test to verify retry behavior

#104 