### PR TITLE
Adding option for a back-channel httpclient mutator

### DIFF
--- a/source/AccessTokenValidation/IdentityServerBearerTokenAuthenticationOptions.cs
+++ b/source/AccessTokenValidation/IdentityServerBearerTokenAuthenticationOptions.cs
@@ -22,6 +22,7 @@ using System.IdentityModel.Tokens;
 using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
+using Microsoft.Owin.Security.Infrastructure;
 
 namespace IdentityServer3.AccessTokenValidation
 {
@@ -84,6 +85,11 @@ namespace IdentityServer3.AccessTokenValidation
         /// The backchannel HTTP handler.
         /// </value>
 		public HttpMessageHandler BackchannelHttpHandler { get; set; }
+
+        /// <summary>
+        /// Gets or sets mutator for the backchannel HTTP client.
+        /// </summary>
+        public Func<HttpClient, AuthenticationTokenReceiveContext, HttpClient> BackchannelHttpClientMutator { get; set; }
 
         /// <summary>
         /// Gets or sets the backchannel certificate validator.


### PR DESCRIPTION
For example this allows adding custom headers to the token validation back-channel request to Identity Server.

One use case is to track the edge request origin and scheme when passing through authenticated requests behind a load balanceer.
