### PR TITLE
Restrict IdentityModel nuspec dependency to versions less than 2.0

### DIFF
--- a/source/IdentityServer3.AccessTokenValidation.nuspec
+++ b/source/IdentityServer3.AccessTokenValidation.nuspec
@@ -23,7 +23,7 @@
       <dependency id="Owin" version="1.0"/>
       <dependency id="Microsoft.Owin.Security.Jwt" version="3.0.1" />
       <dependency id="Microsoft.AspNet.WebApi.Client" version="5.2.3" />
-      <dependency id="IdentityModel" version="1.9.2" />
+      <dependency id="IdentityModel" version="[1.9.2,2.0)" />
       <dependency id="Newtonsoft.Json" version="8.0.3" />
       <dependency id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.2.206221351" />
     </dependencies>


### PR DESCRIPTION
Fix nuspec for https://github.com/IdentityServer/IdentityServer3.AccessTokenValidation/issues/113
Still need to publish a new nuget package though.
