### PR TITLE
Rolling cert support for static config

### DIFF
--- a/source/AccessTokenValidation.Tests/Integration Tests/ResponseHeaders.cs
+++ b/source/AccessTokenValidation.Tests/Integration Tests/ResponseHeaders.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using IdentityServer3.AccessTokenValidation;
 using Owin;
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
@@ -16,7 +17,7 @@ namespace AccessTokenValidation.Tests.Integration_Tests
         IdentityServerBearerTokenAuthenticationOptions _options = new IdentityServerBearerTokenAuthenticationOptions
         {
             IssuerName = TokenFactory.DefaultIssuer,
-            SigningCertificate = new X509Certificate2(Convert.FromBase64String(TokenFactory.DefaultPublicKey)),
+            SigningCertificates = new List<X509Certificate2> { new X509Certificate2(Convert.FromBase64String(TokenFactory.DefaultPublicKey)) },
             ValidationMode = ValidationMode.Local,
             RequiredScopes = new string[] { TokenFactory.Api2Scope }
         };

--- a/source/AccessTokenValidation.Tests/Integration Tests/StaticBoth.cs
+++ b/source/AccessTokenValidation.Tests/Integration Tests/StaticBoth.cs
@@ -2,6 +2,7 @@
 using FluentAssertions;
 using IdentityServer3.AccessTokenValidation;
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
@@ -15,7 +16,7 @@ namespace AccessTokenValidation.Tests.Integration_Tests
         IdentityServerBearerTokenAuthenticationOptions _options = new IdentityServerBearerTokenAuthenticationOptions
         {
             IssuerName = TokenFactory.DefaultIssuer,
-            SigningCertificate = new X509Certificate2(Convert.FromBase64String(TokenFactory.DefaultPublicKey)),
+            SigningCertificates = new List<X509Certificate2> { new X509Certificate2(Convert.FromBase64String(TokenFactory.DefaultPublicKey))},
             Authority = "https://notused",
 
             ValidationMode = ValidationMode.Both

--- a/source/AccessTokenValidation.Tests/Integration Tests/StaticLocal.cs
+++ b/source/AccessTokenValidation.Tests/Integration Tests/StaticLocal.cs
@@ -2,6 +2,7 @@
 using FluentAssertions;
 using IdentityServer3.AccessTokenValidation;
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
@@ -15,7 +16,7 @@ namespace AccessTokenValidation.Tests.Integration_Tests
         IdentityServerBearerTokenAuthenticationOptions _options = new IdentityServerBearerTokenAuthenticationOptions
         {
             IssuerName = TokenFactory.DefaultIssuer,
-            SigningCertificate = new X509Certificate2(Convert.FromBase64String(TokenFactory.DefaultPublicKey)),
+            SigningCertificates = new List<X509Certificate2> { new X509Certificate2(Convert.FromBase64String(TokenFactory.DefaultPublicKey)) },
 
             ValidationMode = ValidationMode.Local
         };

--- a/source/AccessTokenValidation.Tests/Integration Tests/TokenProvider.cs
+++ b/source/AccessTokenValidation.Tests/Integration Tests/TokenProvider.cs
@@ -19,7 +19,7 @@ namespace AccessTokenValidation.Tests.Integration_Tests
         IdentityServerBearerTokenAuthenticationOptions _options = new IdentityServerBearerTokenAuthenticationOptions
         {
             IssuerName = TokenFactory.DefaultIssuer,
-            SigningCertificate = new X509Certificate2(Convert.FromBase64String(TokenFactory.DefaultPublicKey)),
+            SigningCertificates = new List<X509Certificate2> { new X509Certificate2(Convert.FromBase64String(TokenFactory.DefaultPublicKey)) },
 
             ValidationMode = ValidationMode.Local
         };

--- a/source/AccessTokenValidation/IdentityServerBearerTokenAuthenticationOptions.cs
+++ b/source/AccessTokenValidation/IdentityServerBearerTokenAuthenticationOptions.cs
@@ -43,6 +43,7 @@ namespace IdentityServer3.AccessTokenValidation
             ValidationResultCacheDuration = TimeSpan.FromMinutes(5);
             PreserveAccessToken = false;
             DelayLoadMetadata = false;
+            SigningCertificates = new List<X509Certificate2>();
         }
 
         /// <summary>
@@ -62,12 +63,23 @@ namespace IdentityServer3.AccessTokenValidation
         public string IssuerName { get; set; }
 
         /// <summary>
-        /// Gets or sets the signing certificate (if you don't want to use the discovery document).
+        /// Sets the signing certificate (if you don't want to use the discovery document).
         /// </summary>
         /// <value>
         /// The signing certificate.
         /// </value>
-        public X509Certificate2 SigningCertificate { get; set; }
+        public void SigningCertificate(X509Certificate2 cert)
+        {
+            SigningCertificates.Add(cert);
+        }
+
+        /// <summary>
+        /// Gets or sets a list of acceptable signing certificates (if you don't want to use the discovery document).
+        /// </summary>
+        /// <value>
+        /// The signing certificate.
+        /// </value>
+        public IList<X509Certificate2> SigningCertificates { get; set; }
 
         /// <summary>
         /// Gets or sets the validation mode.

--- a/source/AccessTokenValidation/IdentityServerBearerTokenValidationAppBuilderExtensions.cs
+++ b/source/AccessTokenValidation/IdentityServerBearerTokenValidationAppBuilderExtensions.cs
@@ -142,7 +142,7 @@ namespace Owin
 
                 // use static configuration
                 if (!string.IsNullOrWhiteSpace(options.IssuerName) &&
-                    options.SigningCertificate != null)
+                    options.SigningCertificates.Any())
                 {
                     var audience = options.IssuerName.EnsureTrailingSlash();
                     audience += "resources";
@@ -151,8 +151,7 @@ namespace Owin
                     {
                         ValidIssuer = options.IssuerName,
                         ValidAudience = audience,
-                        IssuerSigningToken = new X509SecurityToken(options.SigningCertificate),
-
+                        IssuerSigningTokens = options.SigningCertificates.Select(c => new X509SecurityToken(c)),
                         NameClaimType = options.NameClaimType,
                         RoleClaimType = options.RoleClaimType,
                     };


### PR DESCRIPTION
Make it possible to include a set of certs for static configuration of thumbprint validation.