### PR TITLE
Prevent NullReferenceException in UseIdentityServerBearerTokenAuthentication constructor

### DIFF
--- a/source/AccessTokenValidation.Tests/AccessTokenValidation.Tests.csproj
+++ b/source/AccessTokenValidation.Tests/AccessTokenValidation.Tests.csproj
@@ -123,6 +123,8 @@
     <Compile Include="Integration Tests\StaticLocal.cs" />
     <Compile Include="Integration Tests\TokenProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestIdentityServerBearerTokenValidationMiddleware.cs" />
+    <Compile Include="TestTraceLogger.cs" />
     <Compile Include="Util\DiscoveryEndpointHandler.cs" />
     <Compile Include="Util\FailureDiscoveryEndpointHandler.cs" />
     <Compile Include="Util\IntrospectionEndpointHandler.cs" />

--- a/source/AccessTokenValidation.Tests/TestIdentityServerBearerTokenValidationMiddleware.cs
+++ b/source/AccessTokenValidation.Tests/TestIdentityServerBearerTokenValidationMiddleware.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityServer3.AccessTokenValidation;
+using Moq;
+using Owin;
+using Xunit;
+
+namespace AccessTokenValidation.Tests
+{
+    public class TestIdentityServerBearerTokenValidationMiddleware
+    {
+        [Fact]
+        public void Construct_GivenNullLoggerFactory_ShouldNotThrow_NPE()
+        {
+            // Arrange
+            var options = new IdentityServerOAuthBearerAuthenticationOptions();
+            Func<IDictionary<string, object>, Task> appFunc =
+                d => Task.FromResult(0);
+            var appBuilder = Mock.Of<IAppBuilder>();
+
+            // Act
+            var sut = new IdentityServerBearerTokenValidationMiddleware(
+                appFunc,
+                appBuilder,
+                options,
+                null
+             );
+            
+            // Assert
+            var fieldInfo = sut.GetType().GetField("_logger", BindingFlags.NonPublic | BindingFlags.Instance);
+            fieldInfo.Should().NotBe(null, $"Expected to find private field _logger on {nameof(IdentityServerBearerTokenValidationMiddleware)}");
+            var fieldValue = fieldInfo.GetValue(sut);
+            fieldValue.Should().NotBe(null, "Expected _logger field to have been set during construction");
+            fieldValue.Should().BeOfType<TraceLogger>();
+        }
+    }
+}

--- a/source/AccessTokenValidation.Tests/TestTraceLogger.cs
+++ b/source/AccessTokenValidation.Tests/TestTraceLogger.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using FluentAssertions;
+using IdentityServer3.AccessTokenValidation;
+using Xunit;
+
+namespace AccessTokenValidation.Tests
+{
+    public class TestTraceLogger: IDisposable
+    {
+        private readonly SimpleTraceListener _traceListener;
+        public TestTraceLogger()
+        {
+            _traceListener = new SimpleTraceListener();
+            Trace.Listeners.Add(_traceListener);
+        }
+        public void Dispose()
+        {
+            Trace.Listeners.Remove(_traceListener);
+        }
+
+        public class SimpleTraceListener: TraceListener
+        {
+            public IEnumerable<string> RawMessages => _rawMessages;
+            private readonly List<string> _rawMessages = new List<string>();
+            public IEnumerable<string> LineMessages => _lineMessages;
+            private readonly List<string> _lineMessages = new List<string>();
+            public override void Write(string message)
+            {
+                _rawMessages.Add(message);
+            }
+
+            public override void WriteLine(string message)
+            {
+                _lineMessages.Add(message);
+            }
+        }
+
+        [Fact]
+        public void WriteCore_ShouldWriteToTrace()
+        {
+            // Arrange
+            var sut = new TraceLogger();
+            var eventType = TraceEventType.Information;
+            var eventId = 42;
+            var state = new { foo = "bar" };
+            var exception = new Exception("Something bad happened )':");
+            Func<object, Exception, string> formatter = (s, e) => $"{e.Message} / { s.ToString() }";
+            var expected = $"[${eventId}] {eventType} :: ${formatter(state, exception)}";
+
+            // Act
+            var result = sut.WriteCore(
+                TraceEventType.Information, 
+                eventId,
+                state,
+                exception,
+                formatter
+            );
+
+            // Assert
+            result.Should().BeTrue();
+            _traceListener.RawMessages.Should().BeEmpty();
+            _traceListener.LineMessages.Should().NotBeEmpty();
+            var lineMessage = _traceListener.LineMessages.Single();
+            lineMessage.Should().Be(expected);
+        }
+
+    }
+}

--- a/source/AccessTokenValidation/AccessTokenValidation.csproj
+++ b/source/AccessTokenValidation/AccessTokenValidation.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Plumbing\ScopeRequirementMiddleware.cs" />
     <Compile Include="Plumbing\ValidationMode.cs" />
     <Compile Include="Plumbing\ScopeRequirementOptions.cs" />
+    <Compile Include="TraceLogger.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\default.licenseheader">

--- a/source/AccessTokenValidation/IdentityServerBearerTokenValidationMiddleware.cs
+++ b/source/AccessTokenValidation/IdentityServerBearerTokenValidationMiddleware.cs
@@ -50,7 +50,7 @@ namespace IdentityServer3.AccessTokenValidation
         {
             _next = next;
             _options = options;
-            _logger = loggerFactory.Create(this.GetType().FullName);
+            _logger = loggerFactory?.Create(this.GetType().FullName) ?? new TraceLogger();
 
             if (options.LocalValidationOptions != null)
             {

--- a/source/AccessTokenValidation/TraceLogger.cs
+++ b/source/AccessTokenValidation/TraceLogger.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Diagnostics;
+using Microsoft.Owin.Logging;
+
+namespace IdentityServer3.AccessTokenValidation
+{
+    /// <summary>
+    /// Fallback logger for when OWIN hands in a null logger factory
+    /// </summary>
+    public class TraceLogger: ILogger
+    {
+        /// <inheritdoc />
+        public bool WriteCore(TraceEventType eventType, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)
+        {
+            Trace.WriteLine($"[${eventId}] {eventType} :: ${formatter(state, exception)}");
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Issue occurs when IdentityServer is set up before setting up IdentityServer Bearer Token Authentication.

I ran into this issue myself after a refactoring that happened to move lines about in a way which didn't seem as if it should break things. The issue is also discussed here: [http://stackoverflow.com/questions/31977522/owin-middlware-with-identityserver3-accesstokenvalidation-in-asp-net-5-returns#31989005](http://stackoverflow.com/questions/31977522/owin-middlware-with-identityserver3-accesstokenvalidation-in-asp-net-5-returns#31989005) with the workaround being to move usage of ```UseIdentityServerBearerTokenAuthentication``` above usage of ```UseIdentityServer```.
I'm not advocating this as the only possible way to solve the issue. This is just one way and it has the following benefits:

- Decouples IdentityServerBearerTokenValidationMiddleware from (imo) bad OWIN behaviour
- Would not throw the deeply-concealed NullReferenceException that is (eventually) discovered after trawling through TargetInvocationExceptions

I'm not sure if there's a good reason why ```UseIdentityServerBearerTokenAuthentication``` *must* be called before ```UseIdentityServer``` when embedding IdentityServer. I'm open to correction on this PR.
