### PR TITLE
Adding Additional Constraint To Nuspec. https://github.com/IdentitySe…

### DIFF
--- a/source/IdentityServer3.AccessTokenValidation.nuspec
+++ b/source/IdentityServer3.AccessTokenValidation.nuspec
@@ -26,7 +26,7 @@
       <dependency id="IdentityModel" version="[1.9.2,2.0)" />
       <dependency id="Newtonsoft.Json" version="8.0.3" />
       <dependency id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.2.206221351" />
-	  <dependency id="System.IdentityModel.Tokens.Jwt" version="4.0.2.206221351" />
+      <dependency id="System.IdentityModel.Tokens.Jwt" version="4.0.2.206221351" />
     </dependencies>
   </metadata>
 </package>

--- a/source/IdentityServer3.AccessTokenValidation.nuspec
+++ b/source/IdentityServer3.AccessTokenValidation.nuspec
@@ -26,6 +26,7 @@
       <dependency id="IdentityModel" version="[1.9.2,2.0)" />
       <dependency id="Newtonsoft.Json" version="8.0.3" />
       <dependency id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.2.206221351" />
+	  <dependency id="System.IdentityModel.Tokens.Jwt" version="4.0.2.206221351" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
This pull request adds an additional nuget package constraint to the IdentityServer3.AccessTokenValidation nuspec. 

Highlighted in this issue.
https://github.com/IdentityServer/IdentityServer3.AccessTokenValidation/issues/134

Additional Points:
---------------------
This the simplest possible change, the only thing is, am i being too strict on System.IdentityModel.Tokens.Jwt version="4.0.2.206221351"

In VS nuget is prompting me that its safe to update to version 5.1.2 but i'm not really sure that's a good idea. 

For now this certainly change will at least get the dependencies inline. 

